### PR TITLE
Added in support for SVG camelCase attributes

### DIFF
--- a/lib/rules/camel-case-tag.js
+++ b/lib/rules/camel-case-tag.js
@@ -9,9 +9,14 @@ module.exports = function (node, source, warn) {
     node.__location.startTag
   ) {
     var startTag = getTag(node, source)
+
+    if (node.tagName === startTag.slice(1,-1)) {
+      return
+    }
+
     if (hyphenateRE.test(startTag)) {
       warn(
-        'Found camelCase tag: ' + startTag + '. ' + 
+        'Found camelCase tag: ' + startTag + '. ' +
         'HTML is case-insensitive. ' +
         'Use ' + hyphenate(startTag) + ' instead. ' +
         'Vue will automatically match it against components ' +

--- a/test/test.js
+++ b/test/test.js
@@ -95,7 +95,7 @@ describe('vue-template-validator', function () {
     expect(msg).to.contain('  |            ^')
   })
 
-  it('svg valid attrs', function() {
+  it('svg valid tags', function() {
     var code =
       '<svg>\n' +
       '  <linearGradient></linearGradient>\n' +
@@ -113,7 +113,7 @@ describe('vue-template-validator', function () {
     expect(msg).to.not.exist
   })
 
-  it('svg invalid attrs', function() {
+  it('svg invalid tag', function() {
     var code =
       '<svg>\n' +
       '  <fooBar></fooBar>\n' +

--- a/test/test.js
+++ b/test/test.js
@@ -95,4 +95,37 @@ describe('vue-template-validator', function () {
     expect(msg).to.contain('  |            ^')
   })
 
+  it('svg valid attrs', function() {
+    var code =
+      '<svg>\n' +
+      '  <linearGradient></linearGradient>\n' +
+      '  <clipPath></clipPath>\n' +
+      '</svg>'
+    var warnings = validate(code)
+    expect(warnings.length).to.equal(0)
+    var msg
+    // linearGradient
+    msg = chalk.stripColor(warnings[0])
+    expect(msg).to.not.exist
+
+    // clipPath
+    msg = chalk.stripColor(warnings[1])
+    expect(msg).to.not.exist
+  })
+
+  it('svg invalid attrs', function() {
+    var code =
+      '<svg>\n' +
+      '  <fooBar></fooBar>\n' +
+      '</svg>'
+    var warnings = validate(code)
+    expect(warnings.length).to.equal(1)
+    var msg = chalk.stripColor(warnings[0])
+    expect(msg).to.contain('Found camelCase tag: <fooBar>')
+    expect(msg).to.contain('Use <foo-bar> instead')
+    expect(msg).to.contain('1 | <svg>')
+    expect(msg).to.contain('2 |   <fooBar></fooBar>')
+    expect(msg).to.contain('  |   ^')
+    expect(msg).to.contain('3 | </svg>')
+  })
 })


### PR DESCRIPTION
Added test cases to go along with this feature.

All tests pass. 
There is also a test case that tests an (obviously) invalid tag inside of an SVG element.

I tested this against a template with complex SVGs and no warnings were raised.

This will presumably also support any standard HTML tags that are supposed to be camelCase. Although I am unaware of any at the moment.
